### PR TITLE
Feature: check and fix duplicate paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Keep your [Gitlab's CODEOWNERS file](https://docs.gitlab.com/ee/user/project/cod
 gitlab-codeowners-linter makes sure that the CODEOWNERS file is formatted respecting the following rules:
   - every section must be sorted alphabetically
   - within a section, paths must be ordered alphabetically
+  - paths in a section must be unique
   - there must be no empty lines between paths
 
 The linter can run in check or autofix mode.

--- a/gitlab_codeowners_linter/codeowners_linter.py
+++ b/gitlab_codeowners_linter/codeowners_linter.py
@@ -111,6 +111,32 @@ class OwnersList:
 
                 self.codeowners_data = codeowners_data_updated
 
+        # Are there duplicated paths?
+        sections_with_duplicate_paths = self.get_sections_with_duplicate_paths()
+        if sections_with_duplicate_paths != []:
+            violations.append(
+                f"The sections {', '.join(map(str, sections_with_duplicate_paths))} have duplicate paths",
+            )
+            if self.autofix:
+                codeowners_updated = []
+                for section in self.codeowners_data:
+                    codeowners_updated.append(section)
+                    if section.codeowner_section not in sections_with_duplicate_paths:
+                        continue
+                    updated_entries = []
+                    for entry in section.entries:
+                        if updated_entries == []:
+                            updated_entries.append(entry)
+                            continue
+                        if entry.path == updated_entries[-1].path:
+                            # we have a duplicate
+                            updated_entries[-1].comments.extend(entry.comments)
+                            updated_entries[-1].owners.extend(entry.owners)
+                            continue
+                        updated_entries.append(entry)
+                        codeowners_updated[-1].entries = updated_entries
+                self.codeowners_data = codeowners_updated
+
         if self.autofix:
             self.update_codeowners_file()
         return violations
@@ -129,6 +155,13 @@ class OwnersList:
             if sorted(section.entries, key=sort_paths_key) != section.entries:
                 unsorted_sections.append(section.codeowner_section)
         return unsorted_sections
+
+    def get_sections_with_duplicate_paths(self):
+        sections_with_duplicate_paths = []
+        for section in self.codeowners_data:
+            if len(set(section.get_paths())) != len(section.get_paths()):
+                sections_with_duplicate_paths.append(section.codeowner_section)
+        return sections_with_duplicate_paths
 
     def update_codeowners_file(self):
         with open(self.file_path, 'w') as f:

--- a/tests/codeowoners_linter_tests.py
+++ b/tests/codeowoners_linter_tests.py
@@ -32,7 +32,7 @@ class Test(unittest.TestCase):
 
         testcases = [
             TestCase(
-                name='empty_slice',
+                name='unsorted',
                 input=[
                     '*.md test@email.com',
                     '.gitlab test@email.com',
@@ -46,7 +46,9 @@ class Test(unittest.TestCase):
                     '/WORKSPACE test@email.com',
                     '/www/ test@email.com',
                     '/www/gitlab/test/pa test@email.com #this is a comment',
+                    '/www/**/*.md test@email.com',
                     r'\#file_with_pound.rb test@email.com',
+                    '/www/* test@email.com',
                 ],
                 expected=[
                     '* test@email.com',
@@ -61,6 +63,8 @@ class Test(unittest.TestCase):
                     '/ui/lighting/client test@email.com',
                     '/WORKSPACE test@email.com',
                     '/www/ test@email.com',
+                    '/www/* test@email.com',
+                    '/www/**/*.md test@email.com',
                     '/www/gitlab/test/pa test@email.com #this is a comment',
                 ],
             ),
@@ -149,6 +153,7 @@ class Test(unittest.TestCase):
                     'Sections are not sorted',
                     'There are blank lines in the sections __default_codeowner_section__, BUILD, SECURITY',
                     'The paths in sections __default_codeowner_section__, BUILD, SYSTEM, TEST_SECTION are not sorted',
+                    'The sections __default_codeowner_section__ have duplicate paths',
                 ],
                 expected_fix=os.path.join(
                     os.path.dirname(os.path.abspath(__file__)),

--- a/tests/resources/unformatted_autofix.txt
+++ b/tests/resources/unformatted_autofix.txt
@@ -22,7 +22,7 @@ WORKSPACE test@email.com test1@email.com test2@email.com test3@email.com
 /go/src/github.com/test/path3/ test@email.com
 /go/src/github.com/test/path4/ test@email.com
 /ui test@email.com test1@email.com test2@email.com test3@email.com
-/ui/components/ test@email.com
+/ui/components/ test@email.com test1@email.com test2@email.com
 /ui/lighting test@email.com
 /ui/lighting/client test@email.com
 /WORKSPACE test@email.com test1@email.com test2@email.com test3@email.com

--- a/tests/resources/unformatted_input.txt
+++ b/tests/resources/unformatted_input.txt
@@ -24,11 +24,13 @@ WORKSPACE test@email.com test1@email.com test2@email.com test3@email.com
 /go/src/github.com/test/path4/ test@email.com
 /ui/lighting/client test@email.com
 /ui/lighting test@email.com
+/ui/components/ test@email.com
 /www/ test@email.com
 /www/gitlab/test/path test@email.com
-/ui/components/ test@email.com
+/ui/components/ test1@email.com
 .gitlab test@email.com
 /ui test@email.com test1@email.com test2@email.com test3@email.com
+/ui/components/ test2@email.com
 
 # Build Group
 [BUILD] #this is a comment


### PR DESCRIPTION
In case of duplicate paths in an entry, `autofix` will return a single path with merged owners and comments

Note the order of owners/comments is based on the original order in CODEOWNERS