### PR TITLE
[Feature]Manage optional sections

### DIFF
--- a/gitlab_codeowners_linter/autofix.py
+++ b/gitlab_codeowners_linter/autofix.py
@@ -32,7 +32,13 @@ def fix(codeowners_data, violations, file_path):
         # and DOCUMENTATION are combined, using the case of the first section
         i = 0
         while i < len(codeowners_data)-1:
-            if codeowners_data[i].codeowner_section.lower() == codeowners_data[i+1].codeowner_section.lower():
+            current_section = codeowners_data[i].codeowner_section.lower()
+            if current_section.startswith('^'):
+                current_section = current_section[1:]
+            next_section = codeowners_data[i+1].codeowner_section.lower()
+            if next_section.startswith('^'):
+                next_section = next_section[1:]
+            if current_section == next_section:
                 codeowners_data[i].comments = codeowners_data[i].comments + \
                     codeowners_data[i+1].comments
                 codeowners_data[i].entries = codeowners_data[i].entries + \
@@ -140,7 +146,7 @@ def _update_codeowners_file(codeowners_data, file_path):
                 for comment_line in section.comments:
                     f.write(f'{comment_line}\n')
             if section.codeowner_section != DEFAULT_SECTION:
-                f.write(f'[{section.codeowner_section}]')
+                f.write(f'{section.codeowner_section}')
             if section.entries:
                 f.write('\n')
                 for entry in section.entries:

--- a/gitlab_codeowners_linter/checks.py
+++ b/gitlab_codeowners_linter/checks.py
@@ -85,6 +85,8 @@ def _is_codeowners_empty(codeowners_data):
 def _get_duplicated_sections(codeowners_data):
     all_sections_name = list(
         section.codeowner_section for section in codeowners_data)
+    all_sections_name = [x.split('^')[1] if x.startswith(
+        '^') else x for x in all_sections_name]
     seen = set()
     return [x for x in all_sections_name if x.lower() in seen or seen.add(x.lower())]
 

--- a/gitlab_codeowners_linter/parser.py
+++ b/gitlab_codeowners_linter/parser.py
@@ -44,7 +44,7 @@ def _is_consecutive_blank_line_in_section(codeowners_content):
 
 
 def parse_codeowners(file_path):
-    section_regex = re.compile(r'\[(.*?)\]')
+    section_regex = re.compile(r'(\^)?\[(.*?)\]')
 
     codeowners_content = [CodeownerSection(DEFAULT_SECTION, [], [])]
     comments_block = []
@@ -69,20 +69,16 @@ def parse_codeowners(file_path):
             comments_block = []
             continue
         if section_regex.search(line):
-            # TODO: manage gitlab optional sections, the ones starting with ^
             # TODO: at the moment for any section with a following comment like
             #       [Section]#this is a comment
             #       the comment is ignored without any message to the user.
             #       A solution could be to create a function that scans all the parsed lines for
             #       trailing comments, both on gitlab sections names and on entries, and appends them to
             #       the proper comment space, CodeownerSection.comments or CodeownerEntry.comments
-
             # Here we have a new section
-
             codeowners_content.append(
                 CodeownerSection(
-                    section_regex.search(line).group(
-                        1), comments_block, [],
+                    line.split(']', 1)[0]+']', comments_block, [],
                 ),
             )
             comments_block = []

--- a/gitlab_codeowners_linter/sorting.py
+++ b/gitlab_codeowners_linter/sorting.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import re
+
 
 def sort_paths(entry1, entry2):
     line1 = entry1.path.lower()
@@ -23,8 +25,19 @@ def sort_paths(entry1, entry2):
 
 
 def sort_section_names(section1, section2):
-    section_name1 = section1.codeowner_section.lower()
-    section_name2 = section2.codeowner_section.lower()
+    section_name1 = re.search(re.compile(
+        r'\[([^]]*)\]'), section1.codeowner_section).group(1).lower()
+    section_name2 = re.search(re.compile(
+        r'\[([^]]*)\]'), section2.codeowner_section).group(1).lower()
+    is_section_1_optional = section1.codeowner_section.startswith('^')
+    is_section_2_optional = section2.codeowner_section.startswith('^')
+
     if section_name1 == section_name2:
+        if is_section_1_optional and is_section_2_optional:
+            return 0
+        if is_section_1_optional:
+            return -1
+        if is_section_2_optional:
+            return 1
         return 0
     return -1 if (section_name1 < section_name2) else 1

--- a/tests/resources/optional_sections_autofix.txt
+++ b/tests/resources/optional_sections_autofix.txt
@@ -1,0 +1,35 @@
+### CODEOWNERS ###
+#
+# This is a test case with issues and optional sections
+#
+
+# this is a comment for * test@email.com test1@email.com test2@email.com
+* test@email.com test1@email.com test2@email.com
+*.md test@email.com
+WORKSPACE test@email.com test1@email.com test2@email.com test3@email.com
+/.pylintrc test@email.com
+# this is a comment for /ui test@email.com
+/ui test@email.com
+/ui/components/ test@email.com test1@email.com test2@email.com test3@email.com
+/ui/lighting test@email.com test1@email.com test2@email.com test3@email.com
+
+^[And_a_last_section]
+/pipeline/ test@email.com test1@email.com test2@email.com test3@email.com
+/release/release_script.sh test@email.com
+
+# Gitlab Groups
+[BUILD]
+.gitlab/.gitlab-ci.yml test@email.com
+.gitlab/ci/ test@email.com test1@email.com test2@email.com test3@email.com
+
+[SECURITY]
+/ops/terraform/path1 @test/teams/admin @test/teams/security/admin
+/ops/terraform/path2/ @test/teams/security/admin
+
+# This is a comment for [SYSTEM]
+^[system]
+/docker/pipeline/ test@email.com test1@email.com test2@email.com test3@email.com
+/go/src/repo/pipeline/ test@email.com test1@email.com test2@email.com test3@email.com
+/ops/terraform/pipeline/ test@email.com
+/pipeline/ test1@email.com test2@email.com test3@email.com test@email.com
+/release/release_script.sh test@email.com

--- a/tests/resources/optional_sections_input.txt
+++ b/tests/resources/optional_sections_input.txt
@@ -1,0 +1,44 @@
+### CODEOWNERS ###
+#
+# This is a test case with issues and optional sections
+#
+
+# this is a comment for * test@email.com test1@email.com test2@email.com
+* test@email.com test1@email.com test2@email.com
+*.md test@email.com
+WORKSPACE test@email.com test1@email.com test2@email.com test3@email.com
+/.pylintrc test@email.com
+# this is a comment for /ui test@email.com
+/ui test@email.com
+/ui/components/ test@email.com test1@email.com test2@email.com test3@email.com
+/ui/lighting test@email.com test1@email.com test2@email.com test3@email.com
+
+# Gitlab Groups
+[BUILD]
+.gitlab/.gitlab-ci.yml test@email.com
+.gitlab/ci/ test@email.com test1@email.com test2@email.com test3@email.com
+
+^[system]
+/pipeline/ test@email.com test1@email.com test2@email.com test3@email.com
+
+[SECURITY]
+/ops/terraform/path1 @test/teams/admin @test/teams/security/admin
+/ops/terraform/path2/ @test/teams/security/admin
+
+^[System]
+/pipeline/ test@email.com test1@email.com test2@email.com test3@email.com
+/release/release_script.sh test@email.com
+
+# This is a comment for [SYSTEM]
+[SYSTEM]
+/docker/pipeline/ test@email.com test1@email.com test2@email.com test3@email.com
+/go/src/repo/pipeline/ test@email.com test1@email.com test2@email.com test3@email.com
+/ops/terraform/pipeline/ test@email.com
+
+^[And_a_last_section]
+/pipeline/ test@email.com test1@email.com test2@email.com test3@email.com
+/release/release_script.sh test@email.com
+
+^[SYSTEM]
+/pipeline/ test@email.com test1@email.com test2@email.com test3@email.com
+/release/release_script.sh test@email.com


### PR DESCRIPTION
This adds the optional section feature following the behavior described in the [documentation](https://docs.gitlab.com/ee/user/project/code_owners.html#make-a-code-owners-section-optional).
In case a section with the same name is present both as regular and optional, they are merged under the same optional section.